### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ ax-platform~=0.2.5.1
 PyYAML~=6.0.0
 tqdm~=4.64.0
 setuptools==59.5.0
+fire-0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ ray[tune]~=1.13.0
 ax-platform~=0.2.5.1
 PyYAML~=6.0.0
 tqdm~=4.64.0
+setuptools==59.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ ax-platform~=0.2.5.1
 PyYAML~=6.0.0
 tqdm~=4.64.0
 setuptools==59.5.0
-fire-0.4.0
+fire==0.4.0


### PR DESCRIPTION
- The recent versions of setuptools raise the Error "AttributeError: module 'setuptools._distutils' has no attribute 'version'". This version is required specifically to fix that error.
- Module fire is required to create LMDB dataset
